### PR TITLE
Change install instruction in readme.md to a Pub dependency

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,8 +14,6 @@ In your flutter project add the dependency:
     dependencies:
       ...
       sqflite:
-       git: git://github.com/tekartik/sqflite
-    
 
 For help getting started with Flutter, view the online
 [documentation](https://flutter.io/).


### PR DESCRIPTION
Now that the package is published, most developer will want to depend on the published version, not directly on head of the development repo.