### PR TITLE
Add longer description to pubspec

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,15 @@
+## 0.6.2+1
+
+* Add longer description to pubspec.yaml
+
+## 0.6.2
+
+* Fix travis warning
+
+## 0.6.1
+
+* Add Flutter SDK constraint to pubspec.yaml
+
 ## 0.6.0
 
 * add support for `onConfigure` to allow for database configuration

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,7 +1,8 @@
 name: sqflite
 author: Tekartik <alex@tekartik.com>
 homepage: https://github.com/tekartik/sqflite
-description: SQLite flutter plugin
+description: Flutter plugin for SQLite, a  self-contained, high-reliability,
+  embedded, SQL database engine.
 version: 0.6.2
 
 environment:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -3,7 +3,7 @@ author: Tekartik <alex@tekartik.com>
 homepage: https://github.com/tekartik/sqflite
 description: Flutter plugin for SQLite, a  self-contained, high-reliability,
   embedded, SQL database engine.
-version: 0.6.2
+version: 0.6.2+1
 
 environment:
   sdk: ">=1.24.0 <2.0.0"


### PR DESCRIPTION
Thanks for contributing to the flutter ecosystem, and congrats on landing a package in the Flutter top-20 (https://pub.dartlang.org/flutter) !

This PR suggests adding a slightly longer description to `pubspec.yaml` to provide a better explanation for the package when displayed on the pub site