### PR TITLE
Update SQL helpers section in  README to fix casting errors

### DIFF
--- a/README.md
+++ b/README.md
@@ -105,8 +105,11 @@ class Todo {
   String title;
   bool done;
 
-  Map toMap() {
-    Map map = {columnTitle: title, columnDone: done == true ? 1 : 0};
+  Map<String, dynamic> toMap() {
+    var map = <String, dynamic>{
+      columnTitle: title,
+      columnDone: done == true ? 1 : 0
+    };
     if (id != null) {
       map[columnId] = id;
     }
@@ -115,7 +118,7 @@ class Todo {
 
   Todo();
 
-  Todo.fromMap(Map map) {
+  Todo.fromMap(Map<String, dynamic> map) {
     id = map[columnId];
     title = map[columnTitle];
     done = map[columnDone] == 1;


### PR DESCRIPTION
The troubleshooting document includes information on how to fix the following error

```
Unhandled exception: type '_InternalLinkedHashMap' is not a subtype of type 'Map<String, dynamic>'
 where
  _InternalLinkedHashMap is from dart:collection
  Map is from dart:core
  String is from dart:core
```

However, the sample code in the README hasn't been updated to reflect this so anyone trying to follow the sample will run into the aforementioned error. This PR updates the sample code so this doesn't happen and so that devs won't run into the same problem when trying to follow the demonstrated approach