### PR TITLE
Faster isNotEmpty on collection

### DIFF
--- a/lib/src/sql_builder.dart
+++ b/lib/src/sql_builder.dart
@@ -121,7 +121,7 @@ class SqlBuilder {
     if (distinct == true) {
       query.write("DISTINCT ");
     }
-    if (columns != null && columns.length != 0) {
+    if (columns != null && columns.isNotEmpty) {
       _writeColumns(query, columns);
     } else {
       query.write("* ");


### PR DESCRIPTION
Looks like this can be isNotEmpty instead (https://www.dartlang.org/guides/language/effective-dart/usage#dont-use-length-to-see-if-a-collection-is-empty)