### PR TITLE
Improve doc comments of commonly used functions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,10 +18,10 @@
 ## 0.11.0
 
 * add `getDatabasesPath` to use as the base location to create a database
-* Warning: database are now single instance by default (based on `path`), to use the 
-  old behavior use `singleInstance = kfalse` when opening a database
+* Warning: database are now single instance by default (based on `path`), to use the
+  old behavior use `singleInstance = false` when opening a database
 * dart2 stable support
-  
+
 ## 0.10.0
 
 * Preparing for 1.0
@@ -61,7 +61,7 @@
 ## 0.8.2
 
 * Although already in a transaction, allow creating nested transactions during open
- 
+
 ## 0.8.1
 
 * New `Transaction` mechanism not using Zone (old one still supported for now)
@@ -92,7 +92,7 @@
 ## 0.6.0
 
 * add support for `onConfigure` to allow for database configuration
- 
+
 ## 0.5.0
 
 * Escape table and column name when needed in insert/update/query/delete
@@ -107,14 +107,14 @@
 * Remove temp concurrency experiment
 
 ## 0.3.0
- 
+
 2018/01/04
 
 * **Breaking change**. Upgraded to Gradle 4.1 and Android Studio Gradle plugin
   3.0.1. Older Flutter projects need to upgrade their Gradle setup as well in
   order to use this version of the plugin. Instructions can be found
   [here](https://github.com/flutter/flutter/wiki/Updating-Flutter-projects-to-Gradle-4.1-and-Android-Studio-Gradle-plugin-3.0.1).
-  
+
 ## 0.2.4
 
 * Dependency on synchronized updated to >=1.1.0

--- a/lib/sqflite.dart
+++ b/lib/sqflite.dart
@@ -307,21 +307,55 @@ abstract class OpenDatabaseOptions {
 
 ///
 /// Open the database at a given path
-/// setting a version is optional
-/// [onCreate],  [onUpgrade], [onDowngrade] are called in a transaction
 ///
-/// [onConfigure] is called when the database connection is being configured,
-/// to enable features such as write-ahead logging or foreign key support.
-/// This method is called before [onCreate], [onUpgrade], [onDowngrade]
+/// [version] (optional) specifies the schema version of the database being
+/// opened. This is used to decide whether to call [onCreate], [onUpgrade],
+/// and [onDowngrade]
 ///
-/// [onOpen] is called after [onCreate], [onUpgrade], [onDowngrade] are called
+/// The optional callbacks are called in the following order:
 ///
-/// When [readOnly] is true all other parameters are ignored and the database
-/// is opened as is
+/// 1. [onConfigure]
+/// 2. [onCreate] or [onUpgrade] or [onDowngrade]
+/// 5. [onOpen]
+///
+/// [onConfigure] is the first callback invoked when opening the database. It
+/// allows you to perform database initialization such as enabling foreign keys
+/// or write-ahead logging
+///
+/// If [version] is specified, [onCreate], [onUpgrade], and [onDowngrade] can
+/// be called. These functions are mutually exclusive — only one of them can be
+/// called depending on the context, although they can all be specified to
+/// cover multiple scenarios
+///
+/// [onCreate] is called if the database did not exist prior to calling
+/// [openDatabase]. You can use the opportunity to create the required tables
+/// in the database according to your schema
+///
+/// [onUpgrade] is called if either of the following conditions are met:
+///
+/// 1. [onCreate] is not specified
+/// 2. The database already exists and [version] is higher than the last
+/// database version
+///
+/// In the first case where [onCreate] is not specified, [onUpgrade] is called
+/// with its [oldVersion] parameter as `0`. In the second case, you can perform
+/// the necessary migration procedures to handle the differing schema
+///
+/// [onDowngrade] is called only when [version] is lower than the last database
+/// version. This is a rare case and should only come up if a newer version of
+/// your code has created a database that is then interacted with by an older
+/// version of your code. You should try to avoid this scenario
+///
+/// [onOpen] is the last optional callback to be invoked. It is called after
+/// the database version has been set and before [openDatabase] returns
+///
+/// When [readOnly] (false by default) is true, all other parameters are
+/// ignored and the database is opened as-is
 ///
 /// When [singleInstance] is true (the default), a single database instance is
-/// returned for a given path and other options are ignore if you call
-/// openDatabase again if the database is already opened
+/// returned for a given path. Subsequent calls to [openDatabase] with the
+/// same path will return the same instance, and will discard all other
+/// parameters such as callbacks for that invocation.
 ///
 Future<Database> openDatabase(String path,
     {int version,
@@ -353,13 +387,14 @@ Future<Database> openReadOnlyDatabase(String path) =>
 ///
 /// Get the default databases location
 ///
-/// on Android, it is typically data/data/<package_name>/databases
-/// on iOS, it is the Documents directory
+/// On Android, it is typically data/data/<package_name>/databases
+///
+/// On iOS, it is the Documents directory
 ///
 Future<String> getDatabasesPath() => databaseFactory.getDatabasesPath();
 
 ///
-/// delete the database at the given path
+/// Delete the database at the given path
 ///
 Future<void> deleteDatabase(String path) =>
     databaseFactory.deleteDatabase(path);

--- a/lib/src/database.dart
+++ b/lib/src/database.dart
@@ -16,18 +16,20 @@ abstract class SqfliteDatabaseExecutor implements DatabaseExecutor {
 
   SqfliteDatabase get db;
 
-  /// for sql without return values
+  /// Execute an SQL query with no return value
   @override
   Future<void> execute(String sql, [List<dynamic> arguments]) =>
       db.txnExecute<dynamic>(txn, sql, arguments);
 
-  /// for INSERT sql query
-  /// returns the last inserted record id
+  /// Execute a raw SQL INSERT query
+  ///
+  /// Returns the last inserted record id
   @override
   Future<int> rawInsert(String sql, [List<dynamic> arguments]) =>
       db.txnRawInsert(txn, sql, arguments);
 
-  /// INSERT helper
+  /// Insert a row into a table, where the keys of [values] correspond to
+  /// column names
   @override
   Future<int> insert(String table, Map<String, dynamic> values,
       {String nullColumnHack, ConflictAlgorithm conflictAlgorithm}) {
@@ -86,28 +88,34 @@ abstract class SqfliteDatabaseExecutor implements DatabaseExecutor {
     return rawQuery(builder.sql, builder.arguments);
   }
 
-  /// for SELECT sql query
+  /// Execute a raw SQL SELECT query
+  ///
+  /// Returns a future list of rows that were found
   @override
   Future<List<Map<String, dynamic>>> rawQuery(String sql,
           [List<dynamic> arguments]) =>
       db.txnRawQuery(txn, sql, arguments);
 
-  /// for UPDATE sql query
-  /// return the number of changes made
+  /// Execute a raw SQL UPDATE query
+  ///
+  /// Returns the number of changes made
   @override
   Future<int> rawUpdate(String sql, [List<dynamic> arguments]) =>
       db.txnRawUpdate(txn, sql, arguments);
 
   /// Convenience method for updating rows in the database.
   ///
-  /// update into table [table] with the [values], a map from column names
-  /// to new column values. null is a valid value that will be translated to NULL.
+  /// Update [table] with [values], a map from column names to new column
+  /// values. null is a valid value that will be translated to NULL.
+  ///
   /// [where] is the optional WHERE clause to apply when updating.
-  ///            Passing null will update all rows.
-  /// You may include ?s in the where clause, which
-  ///            will be replaced by the values from [whereArgs]
-  /// optional [conflictAlgorithm] for update conflict resolver
-  /// return the number of rows affected
+  /// Passing null will update all rows.
+  ///
+  /// You may include ?s in the where clause, which will be replaced by the
+  /// values from [whereArgs]
+  ///
+  /// [conflictAlgorithm] (optional) specifies algorithm to use in case of a
+  /// conflict. See [ConflictResolver] docs for more details
   @override
   Future<int> update(String table, Map<String, dynamic> values,
       {String where,
@@ -120,23 +128,29 @@ abstract class SqfliteDatabaseExecutor implements DatabaseExecutor {
     return rawUpdate(builder.sql, builder.arguments);
   }
 
-  /// for DELETE sql query
-  /// return the number of changes made
+  /// Executes a raw SQL DELETE query
+  ///
+  /// Returns the number of changes made
   @override
   Future<int> rawDelete(String sql, [List<dynamic> arguments]) =>
       rawUpdate(sql, arguments);
 
   /// Convenience method for deleting rows in the database.
   ///
-  /// delete from [table]
-  /// [where] is the optional WHERE clause to apply when updating.
-  ///            Passing null will update all rows.
-  /// You may include ?s in the where clause, which
-  ///            will be replaced by the values from [whereArgs]
-  /// optional [conflictAlgorithm] for update conflict resolver
-  /// return the number of rows affected if a whereClause is passed in, 0
-  ///         otherwise. To remove all rows and get a count pass "1" as the
-  ///         whereClause.
+  /// Delete from [table]
+  ///
+  /// [where] is the optional WHERE clause to apply when updating. Passing null
+  /// will update all rows.
+  ///
+  /// You may include ?s in the where clause, which will be replaced by the
+  /// values from [whereArgs]
+  ///
+  /// [conflictAlgorithm] (optional) specifies algorithm to use in case of a
+  /// conflict. See [ConflictResolver] docs for more details
+  ///
+  /// Returns the number of rows affected if a whereClause is passed in, 0
+  /// otherwise. To remove all rows and get a count pass "1" as the
+  /// whereClause.
   @override
   Future<int> delete(String table, {String where, List<dynamic> whereArgs}) {
     final SqlBuilder builder =

--- a/lib/src/database.dart
+++ b/lib/src/database.dart
@@ -542,8 +542,8 @@ class SqfliteDatabase extends SqfliteDatabaseExecutor implements Database {
         Future<void> _onDatabaseDowngradeDelete(
             Database _db, int oldVersion, int newVersion) async {
           final SqfliteDatabase db = _db;
-          // This is tricky as we are in a middel of opening a database
-          // need to close what is being done and retart
+          // This is tricky as we are in the middle of opening a database
+          // need to close what is being done and restart
           await db.execute("ROLLBACK;");
           await db.doClose();
           await deleteDatabase(db.path);

--- a/lib/src/database.dart
+++ b/lib/src/database.dart
@@ -90,7 +90,7 @@ abstract class SqfliteDatabaseExecutor implements DatabaseExecutor {
 
   /// Execute a raw SQL SELECT query
   ///
-  /// Returns a future list of rows that were found
+  /// Returns a list of rows that were found
   @override
   Future<List<Map<String, dynamic>>> rawQuery(String sql,
           [List<dynamic> arguments]) =>


### PR DESCRIPTION
There were a few places where I thought the docs could be reformatted or rewritten a little bit, as some things I didn't initially understand. I hope these changes make the library easier to use for newcomers like me in the future. These are things I noticed as I was learning the library, so there may be more things I notice as I continue to use it.

A few discussion points:
- I think the Dart common practice is to use the form:

```
/// Prints hello world
printHello() {}
```

instead of:

```
/// Print hello world
printHello() {}
```

For describing what a function does, but I've seen different styles used throughout the codebase. Do we want to standardize on one?

- In a few places new lines were getting formatted as one line with the doc comments, as dartdoc uses Markdown. So there might be a few more cases where we should replace this:

```
The quick brown fox
The sky is blue
```

(becomes 'The quick brown fox The sky is blue')

with this:

```
The quick brown fox

The sky is blue
```

(becomes 'The quick brown fox

The sky is blue')

---

I think some of the docs could be brought in to a step by step tutorial which can help those who have little experience, but that sounds like a future prospect.

Let me know if there are some changes you think could be altered.