### PR TITLE
Add link to API reference

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,4 +11,5 @@ Supports both iOS and Android.
 ## Documentation
 
 * [Documentation](https://github.com/tekartik/sqflite/blob/master/sqflite/README.md)
+* [API reference](https://pub.dartlang.org/documentation/sqflite/latest/sqflite/sqflite-library.html)
 * [How to](https://github.com/tekartik/sqflite/blob/master/sqflite/doc/how_to.md) guide


### PR DESCRIPTION
It repeatedly took me a while to find the API reference so I figure this might be a helpful change.