### PR TITLE
Extra open database options

### DIFF
--- a/sqflite/lib/sqlite_api.dart
+++ b/sqflite/lib/sqlite_api.dart
@@ -11,6 +11,7 @@ export 'package:sqflite/src/constant.dart'
         sqfliteLogLevelSql,
         sqfliteLogLevelVerbose;
 export 'package:sqflite/src/exception.dart' show DatabaseException;
+export 'package:sqflite/src/factory_impl.dart' show SqfliteDatabaseFactoryImpl;
 
 /// Basic databases operations
 abstract class DatabaseFactory {
@@ -287,7 +288,8 @@ abstract class OpenDatabaseOptions {
       OnDatabaseVersionChangeFn onDowngrade,
       OnDatabaseOpenFn onOpen,
       bool readOnly = false,
-      bool singleInstance = true}) {
+      bool singleInstance = true,
+      Map<String, dynamic> extraOptions}) {
     return impl.SqfliteOpenDatabaseOptions(
         version: version,
         onConfigure: onConfigure,
@@ -296,7 +298,8 @@ abstract class OpenDatabaseOptions {
         onDowngrade: onDowngrade,
         onOpen: onOpen,
         readOnly: readOnly,
-        singleInstance: singleInstance);
+        singleInstance: singleInstance,
+        extraOptions: extraOptions);
   }
 
   /// Specify the expected version.
@@ -324,6 +327,9 @@ abstract class OpenDatabaseOptions {
 
   /// The existing single-instance (hot-restart)
   bool singleInstance;
+
+  /// Extra options, they will be sent to the native side
+  Map<String, dynamic> extraOptions;
 }
 
 ///

--- a/sqflite/lib/src/database_mixin.dart
+++ b/sqflite/lib/src/database_mixin.dart
@@ -533,6 +533,10 @@ mixin SqfliteDatabaseMixin implements SqfliteDatabase {
     // Single instance?
     params[paramSingleInstance] = singleInstance;
 
+    if (options?.extraOptions != null){
+      params.addAll(options.extraOptions);
+    }
+
     // Version up to 1.1.5 returns an int
     // Now it returns some database information
     // the one being about being recovered from the native world

--- a/sqflite/lib/src/database_mixin.dart
+++ b/sqflite/lib/src/database_mixin.dart
@@ -533,7 +533,7 @@ mixin SqfliteDatabaseMixin implements SqfliteDatabase {
     // Single instance?
     params[paramSingleInstance] = singleInstance;
 
-    if (options?.extraOptions != null){
+    if (options?.extraOptions != null) {
       params.addAll(options.extraOptions);
     }
 

--- a/sqflite/lib/src/open_options.dart
+++ b/sqflite/lib/src/open_options.dart
@@ -15,6 +15,7 @@ class SqfliteOpenDatabaseOptions implements OpenDatabaseOptions {
     this.onOpen,
     this.readOnly = false,
     this.singleInstance = true,
+    this.extraOptions,
   }) {
     readOnly ??= false;
     singleInstance ??= true;
@@ -35,6 +36,8 @@ class SqfliteOpenDatabaseOptions implements OpenDatabaseOptions {
   bool readOnly;
   @override
   bool singleInstance;
+  @override
+  Map<String, dynamic> extraOptions;
 
   @override
   String toString() {
@@ -44,6 +47,9 @@ class SqfliteOpenDatabaseOptions implements OpenDatabaseOptions {
     }
     map['readOnly'] = readOnly;
     map['singleInstance'] = singleInstance;
+    if (map != null) {
+      map.addAll(extraOptions);
+    }
     return map.toString();
   }
 }


### PR DESCRIPTION
Hi @alextekartik , I am thinking on publishing my fork of sqflite that adds SqlCipher support (https://github.com/davidmartos96/sqflite_sqlcipher), but to do that I think it will be better to redo the plugin using the `DatabaseFactory` class from `sqflite` to be able to use a Method Channel with a different name.
I was able to create a much more simple package that uses `sqflite_api.dart` as a dependency and implements the native side of sqflite with the SqlCipher libraries. 
The only thing I need to do that is to export the `SqfliteDatabaseFactoryImpl` class and add an optional parameters map to the `OpenDatabaseOptions` so that they can be passed to the native side and interpreted there. In the case of the sqlcipher plugin, the password parameter is needed.
With those 2 changes the plugin is just these 2 files + native implementation (all in an independent package)

```dart
// MAIN PLUGIN FILE
import 'dart:async';

import 'package:sqflite/sqlite_api.dart';
import 'package:sqflite_sqlcipher/src/factory.dart';

const _kPasswordParam = "password";

Future<Database> openEncryptedDatabase(String path,
    {int version,
    OnDatabaseConfigureFn onConfigure,
    OnDatabaseCreateFn onCreate,
    OnDatabaseVersionChangeFn onUpgrade,
    OnDatabaseVersionChangeFn onDowngrade,
    OnDatabaseOpenFn onOpen,
    String password,
    bool readOnly = false,
    bool singleInstance = true}) {
  final options = OpenDatabaseOptions(
    version: version,
    onConfigure: onConfigure,
    onCreate: onCreate,
    onUpgrade: onUpgrade,
    onDowngrade: onDowngrade,
    onOpen: onOpen,
    readOnly: readOnly,
    singleInstance: singleInstance,
    extraOptions: {
      _kPasswordParam: password,
    },
  );
  return encryptedDatabaseFactory.openDatabase(path, options: options);
}
```

```dart
// factory.dart
import 'package:flutter/services.dart';
import 'package:sqflite/sqlite_api.dart';

/// Sqflite channel name
const String channelName = 'com.davidmartos96.sqflite_sqlcipher';

/// Sqflite channel
const MethodChannel channel = MethodChannel(channelName);

SqfliteSqlCipherDatabaseFactoryImpl _databaseFactory;

/// Default factory
DatabaseFactory get encryptedDatabaseFactory => sqlfliteDatabaseFactory;

/// Default factory
SqfliteSqlCipherDatabaseFactoryImpl get sqlfliteDatabaseFactory =>
    _databaseFactory ??= SqfliteSqlCipherDatabaseFactoryImpl();

/// Factory implementation
class SqfliteSqlCipherDatabaseFactoryImpl extends SqfliteDatabaseFactoryImpl {
  @override
  Future<T> invokeMethod<T>(String method, [arguments]) {
    return channel.invokeMethod(method, arguments);
  }
}

```

The only downside is that if one project only uses `sqflite_sqlcipher`, the native implementation of `sqflite` will be added to the final build although it would not be used. I don't think is much of a problem because Sqlite is bundled on both Android and iOS but ideally it would be great to have a `common_sqflite` dart package at some point.

