### PR TITLE
fix exception.dart getResultCode

### DIFF
--- a/sqflite_common/lib/src/exception.dart
+++ b/sqflite_common/lib/src/exception.dart
@@ -101,7 +101,7 @@ class SqfliteDatabaseException extends DatabaseException {
       final index = message.indexOf(patternPrefix);
       if (index != -1) {
         final code = message.substring(index + patternPrefix.length);
-        final endIndex = code.indexOf(')');
+        final endIndex = code.indexOf(' ');
         if (endIndex != -1) {
           try {
             final resultCode = int.parse(code.substring(0, endIndex));


### PR DESCRIPTION
error messages also include symbolic names which breaks this func ex.:
(code 1 SQLITE_ERROR): , while compiling: INSERT OR ROLLBACK ...