### PR TITLE
fix  exception.dart getResultCode with symbolic name

### DIFF
--- a/sqflite_common/lib/src/exception.dart
+++ b/sqflite_common/lib/src/exception.dart
@@ -104,7 +104,8 @@ class SqfliteDatabaseException extends DatabaseException {
         final endIndex = code.indexOf(')');
         if (endIndex != -1) {
           try {
-            final resultCode = int.parse(code.substring(0, endIndex));
+            final resultCode =
+                int.parse(code.substring(0, endIndex).split(' ')[0]);
             if (resultCode != null) {
               return resultCode;
             }

--- a/sqflite_common/test/sqflite_exception_test.dart
+++ b/sqflite_common/test/sqflite_exception_test.dart
@@ -34,6 +34,19 @@ void main() {
       expect(exception.getResultCode(), 1);
     });
 
+    test('isSyntaxError with symbolic names', () async {
+      // Android
+      final msg = 'near "DUMMY": syntax error (code 1 SQLITE_ERROR)';
+      final exception = SqfliteDatabaseException(msg, null);
+      expect(exception.isDatabaseClosedError(), isFalse);
+      expect(exception.isReadOnlyError(), isFalse);
+      expect(exception.isNoSuchTableError(), isFalse);
+      expect(exception.isOpenFailedError(), isFalse);
+      expect(exception.isSyntaxError(), isTrue);
+      expect(exception.isUniqueConstraintError(), isFalse);
+      expect(exception.getResultCode(), 1);
+    });
+
     test('isNoSuchTable', () async {
       // Android
       final msg = 'no such table: Test (code 1)';


### PR DESCRIPTION
error messages also include symbolic names which breaks this func ex.:
(code 1 SQLITE_ERROR): , while compiling: INSERT OR ROLLBACK ...