### PR TITLE
Use simpler solution to solve race conditions

### DIFF
--- a/sqflite/doc/opening_db.md
+++ b/sqflite/doc/opening_db.md
@@ -195,22 +195,14 @@ Since `openDatabase` is async, there is a race condition risk where openDatabase
 might be called twice. You could fix this with the following:
 
 ```dart
-import 'package:synchronized/synchronized.dart';
-
 class Helper {
   final String path;
   Helper(this.path);
-  Database _db;
-  final _lock = new Lock();
+  Future<Database> _db;
 
-  Future<Database> getDb() async {
+  Future<Database> getDb() {
     if (_db == null) {
-      await _lock.synchronized(() async {
-        // Check again once entering the synchronized block
-        if (_db == null) {
-          _db = await openDatabase(path);
-        }
-      });
+      _db = openDatabase(path);
     }
     return _db;
   }


### PR DESCRIPTION
Because Dart code always runs in a single thread (and isolates don't share memory), there are no memory races and no need for locking. We just need to make sure not to start opening the database again when an open operation is already in progress or completed. The simplest way to achieve that is by just storing and returning the `Future` itself.

If I'm wrong, feel free to ignore this PR :)