### PR TITLE
Switch from moor_ffi to sqlite3

### DIFF
--- a/sqflite_common_ffi/README.md
+++ b/sqflite_common_ffi/README.md
@@ -93,5 +93,4 @@ Future main() async {
 
 * Primary intent was to support unit testing sqflite based code but the implementation works on Windows/Mac/Linux flutter desktop application
 * Database calls are made in a separate isolate,
-* Only `Uint8List` is accepted for blob since `List<int>` is not optimized
 * Multi-instance support (not common) is simulated

--- a/sqflite_common_ffi/README.md
+++ b/sqflite_common_ffi/README.md
@@ -1,6 +1,6 @@
 # sqflite ffi
 
-[sqflite](https://pub.dev/packages/sqflite) based ffi implementation. Based on [`moor_ffi`](https://pub.dev/packages/moor_ffi). Thanks to [Simon Binder](https://github.com/simolus3)
+[sqflite](https://pub.dev/packages/sqflite) based ffi implementation. Based on [`sqlite3`](https://pub.dev/packages/sqlite3). Thanks to [Simon Binder](https://github.com/simolus3)
 
 It allows mocking sqflite during regular flutter unit test (i.e. not using the emulator/simulator).
 One goal is make it stricter than sqflite to encourage good practices.

--- a/sqflite_common_ffi/lib/src/windows/setup.dart
+++ b/sqflite_common_ffi/lib/src/windows/setup.dart
@@ -1,8 +1,8 @@
 import 'dart:ffi';
 import 'dart:io';
 
-import 'package:moor_ffi/database.dart';
-import 'package:moor_ffi/open_helper.dart';
+import 'package:sqlite3/open.dart';
+import 'package:sqlite3/sqlite3.dart';
 import 'package:path/path.dart';
 import 'package:sqflite_common_ffi/src/windows/setup_impl.dart';
 
@@ -22,5 +22,5 @@ void windowsInit() {
 
   // Force an open in the main isolate
   // Loading from an isolate seems to break on windows
-  Database.memory()..close();
+  sqlite3.openInMemory().dispose();
 }

--- a/sqflite_common_ffi/pubspec.yaml
+++ b/sqflite_common_ffi/pubspec.yaml
@@ -7,7 +7,7 @@ environment:
   sdk: ">=2.7.0 <3.0.0"
 
 dependencies:
-  moor_ffi: '>=0.7.0 <1.0.0'
+  sqlite3: '>=0.1.2 <1.0.0'
   sqflite_common: '>=1.0.1 <3.0.0'
   synchronized: '>=2.0.2 <4.0.0'
   path: '>=1.5.1 <3.0.0'
@@ -17,4 +17,3 @@ dev_dependencies:
   pedantic:
   test:
   process_run: '>=0.10.7'
-

--- a/sqflite_common_ffi/test/moor_raw_ffi_test.dart
+++ b/sqflite_common_ffi/test/moor_raw_ffi_test.dart
@@ -2,16 +2,16 @@ import 'dart:io';
 
 import 'package:sqflite_common_ffi/src/windows/setup.dart';
 import 'package:test/test.dart';
-import 'package:moor_ffi/database.dart';
+import 'package:sqlite3/sqlite3.dart';
 
 void main() {
   test('moor_ffi simple test', () {
     if (Platform.isWindows) {
       windowsInit();
     }
-    final database = Database.memory();
-    var version = database.userVersion();
+    final database = sqlite3.openInMemory();
+    var version = database.userVersion;
     expect(version, 0);
-    database.close();
+    database.dispose();
   });
 }


### PR DESCRIPTION
See the announcement in https://github.com/simolus3/moor/issues/691, the non-moor part of `moor_ffi` will be extracted into the independent `sqlite3` package.
This PR migrates `sqflite` usages of `moor_ffi` to the new package. All tests in `sqflite_common_test` and `sqflite_common_ffi` pass for me (on Linux). If there's a way to inspect the performance benchmarks and compare them, I'd love to take a look if there are any regressions.
 
There's one change for users that I can think of: Having a transitive dependency on `moor_ffi` used to include `libsqlite3.so` on Android apps. This will go away with a dependency on `sqlite3`. Since `sqflite_common_ffi` seems to be intended as a dev-dependency only, this is probably what users want anyway. I'm not sure if this is worth noting in a changelog, I just wanted to point it out for completeness.