### PR TITLE
Fix compilation warning

### DIFF
--- a/sqflite/android/src/main/java/com/tekartik/sqflite/SqflitePlugin.java
+++ b/sqflite/android/src/main/java/com/tekartik/sqflite/SqflitePlugin.java
@@ -1040,7 +1040,7 @@ public class SqflitePlugin implements FlutterPlugin, MethodCallHandler {
 
     private class BgResult implements Result {
         // Caller handler
-        final Handler handler = new Handler();
+        final Handler handler = new Handler(Looper.getMainLooper());
         private final Result result;
 
         private BgResult(Result result) {


### PR DESCRIPTION
When building, we get a warning due to the parameterless ctor of Handler being deprecated, as per https://developer.android.com/reference/android/os/Handler. Providing a Looper fixes it.