### PR TITLE
MissingPluginException on release build #452

### DIFF
--- a/sqflite/android/build.gradle
+++ b/sqflite/android/build.gradle
@@ -35,6 +35,7 @@ android {
     defaultConfig {
         minSdkVersion 16
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
+        consumerProguardFiles 'proguard-rules.txt'
     }
     lintOptions {
         disable 'InvalidPackage'

--- a/sqflite/android/proguard-rules.txt
+++ b/sqflite/android/proguard-rules.txt
@@ -1,0 +1,1 @@
+-allowaccessmodification

--- a/sqflite/example/android/app/build.gradle
+++ b/sqflite/example/android/app/build.gradle
@@ -45,6 +45,8 @@ android {
             // TODO: Add your own signing config for the release build.
             // Signing with the debug keys for now, so `flutter run --release` works.
             signingConfig signingConfigs.debug
+            minifyEnabled true
+            shrinkResources true
         }
     }
 }

--- a/sqflite/example/pubspec.yaml
+++ b/sqflite/example/pubspec.yaml
@@ -10,6 +10,8 @@ environment:
 dependencies:
   path: any
   collection: any
+  # image_picker seems to conflict with sqflite if an Android release build with enabled shrinking is performed. Dependency is added to verify this problem is fixed.
+  image_picker: ^0.6.7+14
   flutter:
     sdk: flutter
   sqflite:


### PR DESCRIPTION
Initially I tried to `-keep` just the whole package and played around with the rules. After some tries I got it working and tried to move the rules from my actual app project to the library directly. During this process I realized not the `-keep` rule for the package alone was the fix, but also the usage of `getDefaultProguardFile('proguard-android-optimize.txt')` which I applied during testing.
I also tested `getDefaultProguardFile('proguard-android.txt')` and it wasn't working, so I just diffed both and got the needed rule by trial and error. Lastly I also removed the `-keep` rule itself and funny enough it was still working.

**How to easily test in an app**

Update pubspec.yaml
``` 
# sqflite: ^1.3.2+1 replace the actual production import with the following direct Git branch import
  sqflite:
    git:
      url: git://github.com/Boehrsi/sqflite.git
      path: sqflite
      ref: 452_MissingPluginExceptionOnReleaseBuilds
``` 

Create a minified build, e.g. by just enabling it in debug builds:
```
buildTypes {
        debug {
            minifyEnabled true
            shrinkResources true
        }
    }
```

To ensure the new stuff is really used some rounds of `flutter clean` or `gradlew clean` could be helpful.


**Additional information**

- Link to the default Android ProGuard file: https://android.googlesource.com/platform/sdk/+/master/files/proguard-android.txt
- Link to the default Android optimized ProGuard file: https://android.googlesource.com/platform/sdk/+/master/files/proguard-android-optimize.txt
- ProGuard documentation: https://www.guardsquare.com/en/products/proguard/manual/usage