### PR TITLE
FFI init optional callback for overriding sqlite3 dynamic opening from within the isolate

### DIFF
--- a/sqflite_common_ffi/lib/sqflite_ffi.dart
+++ b/sqflite_common_ffi/lib/sqflite_ffi.dart
@@ -1,5 +1,5 @@
 library sqflite_common_ffi;
 
-export 'src/database_factory_ffi.dart' show FFIInit;
+export 'src/database_factory_ffi.dart' show SqfliteFfiInit;
 export 'src/sqflite_ffi_stub.dart'
     if (dart.library.io) 'src/sqflite_ffi_io.dart';

--- a/sqflite_common_ffi/lib/sqflite_ffi.dart
+++ b/sqflite_common_ffi/lib/sqflite_ffi.dart
@@ -1,4 +1,5 @@
 library sqflite_common_ffi;
 
+export 'src/database_factory_ffi.dart' show FFIInit;
 export 'src/sqflite_ffi_stub.dart'
     if (dart.library.io) 'src/sqflite_ffi_io.dart';

--- a/sqflite_common_ffi/lib/src/database_factory_ffi.dart
+++ b/sqflite_common_ffi/lib/src/database_factory_ffi.dart
@@ -6,13 +6,15 @@ import 'package:synchronized/synchronized.dart';
 
 import 'isolate.dart';
 
+typedef FFIInit = void Function();
+
 DatabaseFactory? _databaseFactoryFfiImpl;
 
 /// The Ffi database factory.
 DatabaseFactory get databaseFactoryFfiImpl =>
     _databaseFactoryFfiImpl ??= createDatabaseFactoryFfiImpl();
 
-DatabaseFactory createDatabaseFactoryFfiImpl({void Function() ffiInit}) {
+DatabaseFactory createDatabaseFactoryFfiImpl({FFIInit? ffiInit}) {
   return buildDatabaseFactory(
         invokeMethod: (String method, [dynamic arguments]) {
       //FfiMethodCall methodCall = FfiMethodCall(method, arguments);
@@ -29,7 +31,7 @@ final _isolateLock = Lock();
 /// Extension on MethodCall
 extension FfiMethodCallHandler on FfiMethodCall {
   /// Handle a method call
-  Future<dynamic> handleInIsolate(void Function() ffiInit) async {
+  Future<dynamic> handleInIsolate(FFIInit? ffiInit) async {
     try {
       if (_debug) {
         print('main_send: $this');
@@ -49,7 +51,7 @@ extension FfiMethodCallHandler on FfiMethodCall {
   }
 
   /// Create the isolate if needed
-  Future<dynamic> _isolateHandle(void Function() ffiInit) async {
+  Future<dynamic> _isolateHandle(FFIInit? ffiInit) async {
     if (_isolate == null) {
       await _isolateLock.synchronized(() async {
         _isolate ??= await createIsolate(ffiInit);

--- a/sqflite_common_ffi/lib/src/database_factory_ffi.dart
+++ b/sqflite_common_ffi/lib/src/database_factory_ffi.dart
@@ -6,6 +6,7 @@ import 'package:synchronized/synchronized.dart';
 
 import 'isolate.dart';
 
+/// Signature responsible for overriding the SQLite dynamic library to use 
 typedef FFIInit = void Function();
 
 DatabaseFactory? _databaseFactoryFfiImpl;
@@ -14,11 +15,11 @@ DatabaseFactory? _databaseFactoryFfiImpl;
 DatabaseFactory get databaseFactoryFfiImpl =>
     _databaseFactoryFfiImpl ??= createDatabaseFactoryFfiImpl();
 
+/// Creates an FFI database factory
 DatabaseFactory createDatabaseFactoryFfiImpl({FFIInit? ffiInit}) {
   return buildDatabaseFactory(
         invokeMethod: (String method, [dynamic arguments]) {
-      //FfiMethodCall methodCall = FfiMethodCall(method, arguments);
-      var methodCall = FfiMethodCall(method, arguments);
+      final methodCall = FfiMethodCall(method, arguments);
       return methodCall.handleInIsolate(ffiInit);
     });
 }

--- a/sqflite_common_ffi/lib/src/database_factory_ffi.dart
+++ b/sqflite_common_ffi/lib/src/database_factory_ffi.dart
@@ -7,7 +7,7 @@ import 'package:synchronized/synchronized.dart';
 import 'isolate.dart';
 
 /// Signature responsible for overriding the SQLite dynamic library to use 
-typedef FFIInit = void Function();
+typedef SqfliteFfiInit = void Function();
 
 DatabaseFactory? _databaseFactoryFfiImpl;
 
@@ -16,7 +16,7 @@ DatabaseFactory get databaseFactoryFfiImpl =>
     _databaseFactoryFfiImpl ??= createDatabaseFactoryFfiImpl();
 
 /// Creates an FFI database factory
-DatabaseFactory createDatabaseFactoryFfiImpl({FFIInit? ffiInit}) {
+DatabaseFactory createDatabaseFactoryFfiImpl({SqfliteFfiInit? ffiInit}) {
   return buildDatabaseFactory(
         invokeMethod: (String method, [dynamic arguments]) {
       final methodCall = FfiMethodCall(method, arguments);
@@ -32,7 +32,7 @@ final _isolateLock = Lock();
 /// Extension on MethodCall
 extension FfiMethodCallHandler on FfiMethodCall {
   /// Handle a method call
-  Future<dynamic> handleInIsolate(FFIInit? ffiInit) async {
+  Future<dynamic> handleInIsolate(SqfliteFfiInit? ffiInit) async {
     try {
       if (_debug) {
         print('main_send: $this');
@@ -52,7 +52,7 @@ extension FfiMethodCallHandler on FfiMethodCall {
   }
 
   /// Create the isolate if needed
-  Future<dynamic> _isolateHandle(FFIInit? ffiInit) async {
+  Future<dynamic> _isolateHandle(SqfliteFfiInit? ffiInit) async {
     if (_isolate == null) {
       await _isolateLock.synchronized(() async {
         _isolate ??= await createIsolate(ffiInit);

--- a/sqflite_common_ffi/lib/src/database_factory_ffi.dart
+++ b/sqflite_common_ffi/lib/src/database_factory_ffi.dart
@@ -10,12 +10,16 @@ DatabaseFactory? _databaseFactoryFfiImpl;
 
 /// The Ffi database factory.
 DatabaseFactory get databaseFactoryFfiImpl =>
-    _databaseFactoryFfiImpl ??= buildDatabaseFactory(
+    _databaseFactoryFfiImpl ??= createDatabaseFactoryFfiImpl();
+
+DatabaseFactory createDatabaseFactoryFfiImpl({void Function() ffiInit}) {
+  return buildDatabaseFactory(
         invokeMethod: (String method, [dynamic arguments]) {
       //FfiMethodCall methodCall = FfiMethodCall(method, arguments);
       var methodCall = FfiMethodCall(method, arguments);
-      return methodCall.handleInIsolate();
+      return methodCall.handleInIsolate(ffiInit);
     });
+}
 
 bool _debug = false; // devWarning(true);
 
@@ -25,12 +29,12 @@ final _isolateLock = Lock();
 /// Extension on MethodCall
 extension FfiMethodCallHandler on FfiMethodCall {
   /// Handle a method call
-  Future<dynamic> handleInIsolate() async {
+  Future<dynamic> handleInIsolate(void Function() ffiInit) async {
     try {
       if (_debug) {
         print('main_send: $this');
       }
-      var result = await _isolateHandle();
+      var result = await _isolateHandle(ffiInit);
       if (_debug) {
         print('main_recv: $result');
       }
@@ -45,10 +49,10 @@ extension FfiMethodCallHandler on FfiMethodCall {
   }
 
   /// Create the isolate if needed
-  Future<dynamic> _isolateHandle() async {
+  Future<dynamic> _isolateHandle(void Function() ffiInit) async {
     if (_isolate == null) {
       await _isolateLock.synchronized(() async {
-        _isolate ??= await createIsolate();
+        _isolate ??= await createIsolate(ffiInit);
       });
     }
     return await _isolate!.handle(this);

--- a/sqflite_common_ffi/lib/src/isolate.dart
+++ b/sqflite_common_ffi/lib/src/isolate.dart
@@ -1,5 +1,6 @@
 import 'dart:isolate';
 
+import 'package:sqflite_common_ffi/src/database_factory_ffi.dart';
 import 'package:sqflite_common_ffi/src/import.dart';
 import 'package:sqflite_common_ffi/src/method_call.dart';
 import 'package:sqflite_common_ffi/src/sqflite_ffi_exception.dart';
@@ -49,7 +50,7 @@ class SqfliteIsolate {
 }
 
 /// Create an isolate.
-Future<SqfliteIsolate> createIsolate(void Function() ffiInit) async {
+Future<SqfliteIsolate> createIsolate(FFIInit? ffiInit) async {
   // create a long-lived port for receiving messages
   var ourFirstReceivePort = ReceivePort();
 
@@ -71,7 +72,7 @@ Future _isolate(List<dynamic> args) async {
   var ourReceivePort = ReceivePort();
 
   final sendPort = args[0] as SendPort;
-  final ffiInit = (args[1] as void Function());
+  final ffiInit = (args[1] as FFIInit?);
 
   // Initialize with the FFI callback if provided
   ffiInit?.call();

--- a/sqflite_common_ffi/lib/src/isolate.dart
+++ b/sqflite_common_ffi/lib/src/isolate.dart
@@ -50,7 +50,7 @@ class SqfliteIsolate {
 }
 
 /// Create an isolate.
-Future<SqfliteIsolate> createIsolate(FFIInit? ffiInit) async {
+Future<SqfliteIsolate> createIsolate(SqfliteFfiInit? ffiInit) async {
   // create a long-lived port for receiving messages
   var ourFirstReceivePort = ReceivePort();
 
@@ -72,7 +72,7 @@ Future _isolate(List<dynamic> args) async {
   var ourReceivePort = ReceivePort();
 
   final sendPort = args[0] as SendPort;
-  final ffiInit = (args[1] as FFIInit?);
+  final ffiInit = (args[1] as SqfliteFfiInit?);
 
   // Initialize with the FFI callback if provided
   ffiInit?.call();

--- a/sqflite_common_ffi/lib/src/sqflite_ffi_io.dart
+++ b/sqflite_common_ffi/lib/src/sqflite_ffi_io.dart
@@ -11,7 +11,7 @@ import 'package:sqflite_common_ffi/src/windows/setup.dart';
 /// Currently supports Win/Mac/Linux.
 DatabaseFactory get databaseFactoryFfi => databaseFactoryFfiImpl;
 
-DatabaseFactory createDatabaseFactoryFfi({void Function() ffiInit}) => createDatabaseFactoryFfiImpl(ffiInit: ffiInit);
+DatabaseFactory createDatabaseFactoryFfi({FFIInit? ffiInit}) => createDatabaseFactoryFfiImpl(ffiInit: ffiInit);
 
 /// Optional. Initialize ffi loader.
 ///

--- a/sqflite_common_ffi/lib/src/sqflite_ffi_io.dart
+++ b/sqflite_common_ffi/lib/src/sqflite_ffi_io.dart
@@ -16,6 +16,25 @@ DatabaseFactory get databaseFactoryFfi => databaseFactoryFfiImpl;
 /// some behavior with the sqlite3 dynamic library opening. This function should
 /// be either a top level function or a static function.
 /// Prefer the use of the [databaseFactoryFfi] getter if you don't need this functionality.
+/// 
+/// Example for overriding the sqlite library in Windows by providing a custom path.
+///
+/// ```dart
+/// import 'package:sqlite3/open.dart';
+/// 
+/// void ffiInit() {
+///   open.overrideFor(
+///     OperatingSystem.windows,
+///     () => DynamicLibrary.open('path/to/bundled/sqlite.dll'),
+///   );
+/// }
+/// 
+/// Future<void> main() async {
+///   final dbFactory = createDatabaseFactoryFfi(ffiInit: ffiInit);
+///   final db = await dbFactory.openDatabase(inMemoryDatabasePath);
+///   ...
+/// }
+/// ```
 DatabaseFactory createDatabaseFactoryFfi({FFIInit? ffiInit}) {
   return createDatabaseFactoryFfiImpl(ffiInit: ffiInit);
 }

--- a/sqflite_common_ffi/lib/src/sqflite_ffi_io.dart
+++ b/sqflite_common_ffi/lib/src/sqflite_ffi_io.dart
@@ -11,6 +11,8 @@ import 'package:sqflite_common_ffi/src/windows/setup.dart';
 /// Currently supports Win/Mac/Linux.
 DatabaseFactory get databaseFactoryFfi => databaseFactoryFfiImpl;
 
+DatabaseFactory createDatabaseFactoryFfi({void Function() ffiInit}) => createDatabaseFactoryFfiImpl(ffiInit: ffiInit);
+
 /// Optional. Initialize ffi loader.
 ///
 /// Call in main until you find a loader for your needs.

--- a/sqflite_common_ffi/lib/src/sqflite_ffi_io.dart
+++ b/sqflite_common_ffi/lib/src/sqflite_ffi_io.dart
@@ -35,7 +35,7 @@ DatabaseFactory get databaseFactoryFfi => databaseFactoryFfiImpl;
 ///   ...
 /// }
 /// ```
-DatabaseFactory createDatabaseFactoryFfi({FFIInit? ffiInit}) {
+DatabaseFactory createDatabaseFactoryFfi({SqfliteFfiInit? ffiInit}) {
   return createDatabaseFactoryFfiImpl(ffiInit: ffiInit);
 }
 

--- a/sqflite_common_ffi/lib/src/sqflite_ffi_io.dart
+++ b/sqflite_common_ffi/lib/src/sqflite_ffi_io.dart
@@ -11,7 +11,14 @@ import 'package:sqflite_common_ffi/src/windows/setup.dart';
 /// Currently supports Win/Mac/Linux.
 DatabaseFactory get databaseFactoryFfi => databaseFactoryFfiImpl;
 
-DatabaseFactory createDatabaseFactoryFfi({FFIInit? ffiInit}) => createDatabaseFactoryFfiImpl(ffiInit: ffiInit);
+/// Creates an FFI database factory.
+/// Optionally the FFIInit function can be provided if you want to override
+/// some behavior with the sqlite3 dynamic library opening. This function should
+/// be either a top level function or a static function.
+/// Prefer the use of the [databaseFactoryFfi] getter if you don't need this functionality.
+DatabaseFactory createDatabaseFactoryFfi({FFIInit? ffiInit}) {
+  return createDatabaseFactoryFfiImpl(ffiInit: ffiInit);
+}
 
 /// Optional. Initialize ffi loader.
 ///

--- a/sqflite_common_ffi/lib/src/sqflite_ffi_stub.dart
+++ b/sqflite_common_ffi/lib/src/sqflite_ffi_stub.dart
@@ -9,31 +9,8 @@ import 'package:sqflite_common_ffi/src/database_factory_ffi.dart';
 DatabaseFactory get databaseFactoryFfi => throw UnimplementedError(
     'databaseFactoryFfi only supported for io application');
 
-/// Creates an FFI database factory.
-/// Optionally the FFIInit function can be provided if you want to override
-/// some behavior with the sqlite3 dynamic library opening. This function should
-/// be either a top level function or a static function.
-/// Prefer the use of the [databaseFactoryFfi] getter if you don't need this functionality.
-///
-/// Example for overriding the sqlite library in Windows by providing a custom path.
-///
-/// ```dart
-/// import 'package:sqlite3/open.dart';
-/// 
-/// void ffiInit() {
-///   open.overrideFor(
-///     OperatingSystem.windows,
-///     () => DynamicLibrary.open('path/to/bundled/sqlite.dll'),
-///   );
-/// }
-/// 
-/// Future<void> main() async {
-///   final dbFactory = createDatabaseFactoryFfi(ffiInit: ffiInit);
-///   final db = await dbFactory.openDatabase(inMemoryDatabasePath);
-///   ...
-/// }
-/// ```
-DatabaseFactory createDatabaseFactoryFfi({FFIInit? ffiInit}) => throw UnimplementedError(
+/// Creates an FFI database factory
+DatabaseFactory createDatabaseFactoryFfi({SqfliteFfiInit? ffiInit}) => throw UnimplementedError(
     'createDatabaseFactoryFfi only supported for io application');
 
 /// Optional. Initialize ffi loader.

--- a/sqflite_common_ffi/lib/src/sqflite_ffi_stub.dart
+++ b/sqflite_common_ffi/lib/src/sqflite_ffi_stub.dart
@@ -1,4 +1,5 @@
 import 'package:sqflite_common/sqlite_api.dart';
+import 'package:sqflite_common_ffi/src/database_factory_ffi.dart';
 
 /// The database factory to use for ffi.
 ///
@@ -8,7 +9,7 @@ import 'package:sqflite_common/sqlite_api.dart';
 DatabaseFactory get databaseFactoryFfi => throw UnimplementedError(
     'databaseFactoryFfi only supported for io application');
 
-DatabaseFactory createDatabaseFactoryFfi({void Function() ffiInit}) => throw UnimplementedError(
+DatabaseFactory createDatabaseFactoryFfi({FFIInit? ffiInit}) => throw UnimplementedError(
     'createDatabaseFactoryFfi only supported for io application');
 
 /// Optional. Initialize ffi loader.

--- a/sqflite_common_ffi/lib/src/sqflite_ffi_stub.dart
+++ b/sqflite_common_ffi/lib/src/sqflite_ffi_stub.dart
@@ -8,6 +8,9 @@ import 'package:sqflite_common/sqlite_api.dart';
 DatabaseFactory get databaseFactoryFfi => throw UnimplementedError(
     'databaseFactoryFfi only supported for io application');
 
+DatabaseFactory createDatabaseFactoryFfi({void Function() ffiInit}) => throw UnimplementedError(
+    'createDatabaseFactoryFfi only supported for io application');
+
 /// Optional. Initialize ffi loader.
 ///
 /// Call in main until you find a loader for your needs.

--- a/sqflite_common_ffi/lib/src/sqflite_ffi_stub.dart
+++ b/sqflite_common_ffi/lib/src/sqflite_ffi_stub.dart
@@ -14,6 +14,25 @@ DatabaseFactory get databaseFactoryFfi => throw UnimplementedError(
 /// some behavior with the sqlite3 dynamic library opening. This function should
 /// be either a top level function or a static function.
 /// Prefer the use of the [databaseFactoryFfi] getter if you don't need this functionality.
+///
+/// Example for overriding the sqlite library in Windows by providing a custom path.
+///
+/// ```dart
+/// import 'package:sqlite3/open.dart';
+/// 
+/// void ffiInit() {
+///   open.overrideFor(
+///     OperatingSystem.windows,
+///     () => DynamicLibrary.open('path/to/bundled/sqlite.dll'),
+///   );
+/// }
+/// 
+/// Future<void> main() async {
+///   final dbFactory = createDatabaseFactoryFfi(ffiInit: ffiInit);
+///   final db = await dbFactory.openDatabase(inMemoryDatabasePath);
+///   ...
+/// }
+/// ```
 DatabaseFactory createDatabaseFactoryFfi({FFIInit? ffiInit}) => throw UnimplementedError(
     'createDatabaseFactoryFfi only supported for io application');
 

--- a/sqflite_common_ffi/lib/src/sqflite_ffi_stub.dart
+++ b/sqflite_common_ffi/lib/src/sqflite_ffi_stub.dart
@@ -9,6 +9,11 @@ import 'package:sqflite_common_ffi/src/database_factory_ffi.dart';
 DatabaseFactory get databaseFactoryFfi => throw UnimplementedError(
     'databaseFactoryFfi only supported for io application');
 
+/// Creates an FFI database factory.
+/// Optionally the FFIInit function can be provided if you want to override
+/// some behavior with the sqlite3 dynamic library opening. This function should
+/// be either a top level function or a static function.
+/// Prefer the use of the [databaseFactoryFfi] getter if you don't need this functionality.
 DatabaseFactory createDatabaseFactoryFfi({FFIInit? ffiInit}) => throw UnimplementedError(
     'createDatabaseFactoryFfi only supported for io application');
 


### PR DESCRIPTION
Fixes: #551 

@alextekartik Please let me know if you would like to move something around or rename the method/typedef. I don't have much experience with stub imports in Dart.
Should the docstring be repeated for the stub file and for the io file?
