### PR TITLE
Remove unused dart:async imports

### DIFF
--- a/sqflite_common/lib/src/database.dart
+++ b/sqflite_common/lib/src/database.dart
@@ -1,5 +1,3 @@
-import 'dart:async';
-
 import 'package:sqflite_common/sqlite_api.dart';
 import 'package:sqflite_common/src/batch.dart';
 import 'package:sqflite_common/src/factory.dart';

--- a/sqflite_common/lib/src/factory.dart
+++ b/sqflite_common/lib/src/factory.dart
@@ -1,5 +1,3 @@
-import 'dart:async';
-
 import 'package:sqflite_common/sqlite_api.dart';
 import 'package:sqflite_common/src/database.dart';
 import 'package:sqflite_common/src/mixin/factory.dart';

--- a/sqflite_common/lib/src/factory_mixin.dart
+++ b/sqflite_common/lib/src/factory_mixin.dart
@@ -1,5 +1,3 @@
-import 'dart:async';
-
 import 'package:path/path.dart';
 import 'package:sqflite_common/sqlite_api.dart';
 import 'package:sqflite_common/src/constant.dart';


### PR DESCRIPTION
As of Dart 2.1, Future/Stream have been exported from dart:core.