### PR TITLE
Bump sqlite3 to >=0.1.10-nullsafety.0

### DIFF
--- a/sqflite_common/tool/travis.dart
+++ b/sqflite_common/tool/travis.dart
@@ -37,7 +37,7 @@ dart test
           final dir = await Directory.systemTemp.createTemp('sqflite_common');
           bashFilePath = join(dir.path, 'codecov.bash');
           await File(bashFilePath)
-              .writeAsString(await IOClient().read('https://codecov.io/bash'));
+              .writeAsString(await IOClient().read(Uri.parse('https://codecov.io/bash')));
           await shell.run('bash $bashFilePath');
         } catch (e) {
           stdout.writeln('error $e running $bashFilePath');

--- a/sqflite_common_ffi/pubspec.yaml
+++ b/sqflite_common_ffi/pubspec.yaml
@@ -7,7 +7,7 @@ environment:
   sdk: '>=2.12.0-29 <3.0.0'
 
 dependencies:
-  sqlite3: '>=0.1.9-nullsafety.0 <1.0.0'
+  sqlite3: '>=0.1.10-nullsafety.0 <1.0.0'
   sqflite_common: '>=2.0.0-nullsafety.2 <3.0.0'
   synchronized: '>=3.0.0-nullsafety.0 <4.0.0'
   path: '>=1.8.0-nullsafety.3 <3.0.0'


### PR DESCRIPTION
Rationale: a project I'm working on depends on both sqflite and shared_preferences, I'm working on supporting sound null safety, but at the moment shared_preferences has a transitional dependency on `ffi >=0.3.0-nullsafety.1`, whereas sqflite has a transitional dependency (via `sqlite3 >=0.1.9-nullsafety.0`) on `ffi ^0.2.0-nullsafety`. It's a minor update so it shouldn't break anything major.