### PR TITLE
Give variable `firstOpen` a type to prepare for Dart language bugfix.

### DIFF
--- a/sqflite_common/lib/src/factory_mixin.dart
+++ b/sqflite_common/lib/src/factory_mixin.dart
@@ -98,13 +98,16 @@ mixin SqfliteDatabaseFactoryMixin
 
         var databaseOpenHelper = getExistingDatabaseOpenHelper(path);
 
-        final firstOpen = databaseOpenHelper == null;
+        // TODO(https://github.com/dart-lang/sdk/issues/47065): remove this
+        // explicit `bool` type when no longer needed to work around
+        // https://github.com/dart-lang/language/issues/1785
+        final bool firstOpen = databaseOpenHelper == null;
         if (firstOpen) {
           databaseOpenHelper = SqfliteDatabaseOpenHelper(this, path, options);
           setDatabaseOpenHelper(databaseOpenHelper);
         }
         try {
-          return await databaseOpenHelper!.openDatabase();
+          return await databaseOpenHelper.openDatabase();
         } catch (e) {
           // If first open fail remove the reference
           if (firstOpen) {


### PR DESCRIPTION
This change prepares for the Dart language to roll out the fix for
https://github.com/dart-lang/language/issues/1785.  This bug prevents
implicitly typed condition variables from participating in type
promotion in some circumstances (see the bug for more details).
There's one variable in this package that's affected - the `firstOpen`
variable.  Since the bug only occurs when the condition variable is
implicitly typed, we can ensure a smooth rollout by giving `firstOpen`
an explicit `bool` type.  Once the fix has fully rolled out, and the
package depends on a version of Dart that includes the bug fix, we
will be able to remove this explicit type once again.