### PR TITLE
Fix Experimental Test for Issue #164

### DIFF
--- a/sqflite/example/lib/exp_test_page.dart
+++ b/sqflite/example/lib/exp_test_page.dart
@@ -437,7 +437,7 @@ CREATE TABLE test (
         id = await db.rawInsert('''
         INSERT INTO test (label) VALUES(?)
         ''', ['label-1']);
-        expect(id, null);
+        expect(id, 0);
       } finally {
         await db.close();
       }


### PR DESCRIPTION
Based on `sqflite_common` library, `rawInsert` will return 0
as id instead of null if no record was inserted in the DB.

**Refs**

1. https://github.com/tekartik/sqflite/blob/996e899e6d2373edc492ece62ba27ff482e3ca10/sqflite_common/lib/sqlite_api.dart#L72
2. https://github.com/tekartik/sqflite/blob/996e899e6d2373edc492ece62ba27ff482e3ca10/sqflite_common/lib/src/database_mixin.dart#L391