### PR TITLE
Use Process.THREAD_PRIORITY_DEFAULT for the background thread

### DIFF
--- a/sqflite/android/src/main/java/com/tekartik/sqflite/SqflitePlugin.java
+++ b/sqflite/android/src/main/java/com/tekartik/sqflite/SqflitePlugin.java
@@ -71,7 +71,7 @@ public class SqflitePlugin implements FlutterPlugin, MethodCallHandler {
 
     static final Map<String, Integer> _singleInstancesByPath = new HashMap<>();
     static private boolean QUERY_AS_MAP_LIST = false; // set by options
-    static private int THREAD_PRIORITY = Process.THREAD_PRIORITY_BACKGROUND;
+    static private int THREAD_PRIORITY = Process.THREAD_PRIORITY_DEFAULT;
     static int logLevel = LogLevel.none;
 
     static private final Object databaseMapLocker = new Object();


### PR DESCRIPTION
Fixes #738

As mentioned in the linked issue, using a lower thread priority of `THREAD_PRIORITY_BACKGROUND` can cause the thread to stall when there are less cpu cycles available. This PR increases the priority to `THREAD_PRIORITY_DEFAULT`.

For reference, the android embedding sets the priority of the UI thread to [`-1`](https://github.com/flutter/engine/blob/ffa298925553150ece8ad6b08090b0fa31d023a6/shell/platform/android/android_shell_holder.cc#L106-L107) (lower value is higher priority). `THREAD_PRIORITY_DEFAULT` is `0` so the UI thread should still have a higher priority.