### PR TITLE
Remove workaround for Dart language bugfix.

### DIFF
--- a/sqflite_common/lib/src/factory_mixin.dart
+++ b/sqflite_common/lib/src/factory_mixin.dart
@@ -98,11 +98,7 @@ mixin SqfliteDatabaseFactoryMixin
 
         var databaseOpenHelper = getExistingDatabaseOpenHelper(path);
 
-        // TODO(https://github.com/dart-lang/sdk/issues/47065): remove this
-        // explicit `bool` type when no longer needed to work around
-        // https://github.com/dart-lang/language/issues/1785
-        // ignore: omit_local_variable_types
-        final bool firstOpen = databaseOpenHelper == null;
+        final firstOpen = databaseOpenHelper == null;
         if (firstOpen) {
           databaseOpenHelper = SqfliteDatabaseOpenHelper(this, path, options);
           setDatabaseOpenHelper(databaseOpenHelper);

--- a/sqflite_common/pubspec.yaml
+++ b/sqflite_common/pubspec.yaml
@@ -4,7 +4,7 @@ description: Dart wrapper on SQLite, a self-contained, high-reliability, embedde
 version: 2.0.1+1
 
 environment:
-  sdk: '>=2.12.0 <3.0.0'
+  sdk: '>=2.15.0 <3.0.0'
 
 dependencies:
   synchronized: '>=3.0.0 <5.0.0'


### PR DESCRIPTION
This change removes the hack introduced by
https://github.com/tekartik/sqflite/pull/696, which was a workaround
for https://github.com/dart-lang/language/issues/1785.