### PR TITLE
Implemented background platform channels

### DIFF
--- a/sqflite/android/src/main/java/com/tekartik/sqflite/SqflitePlugin.java
+++ b/sqflite/android/src/main/java/com/tekartik/sqflite/SqflitePlugin.java
@@ -32,6 +32,7 @@ import io.flutter.plugin.common.MethodCall;
 import io.flutter.plugin.common.MethodChannel;
 import io.flutter.plugin.common.MethodChannel.MethodCallHandler;
 import io.flutter.plugin.common.MethodChannel.Result;
+import io.flutter.plugin.common.StandardMethodCodec;
 
 import static com.tekartik.sqflite.Constant.CMD_GET;
 import static com.tekartik.sqflite.Constant.ERROR_BAD_PARAM;
@@ -113,7 +114,9 @@ public class SqflitePlugin implements FlutterPlugin, MethodCallHandler {
 
     private void onAttachedToEngine(Context applicationContext, BinaryMessenger messenger) {
         this.context = applicationContext;
-        methodChannel = new MethodChannel(messenger, Constant.PLUGIN_KEY);
+        methodChannel = new MethodChannel(messenger, Constant.PLUGIN_KEY,
+                                          StandardMethodCodec.INSTANCE,
+                                          messenger.makeBackgroundTaskQueue());
         methodChannel.setMethodCallHandler(this);
     }
 

--- a/sqflite/example/android/app/build.gradle
+++ b/sqflite/example/android/app/build.gradle
@@ -60,6 +60,6 @@ dependencies {
     androidTestImplementation 'androidx.test.ext:junit:1.1.2'
     androidTestImplementation 'androidx.test:runner:1.3.0'
     androidTestImplementation 'androidx.test:runner:1.3.0'
-    androidTestImplementation 'androidx.test.espresso:espresso-core:3.3.0'
+    androidTestImplementation 'androidx.test.espresso:espresso-core:3.2.0'
     implementation 'androidx.test:rules:1.3.0'
 }

--- a/sqflite/ios/Classes/SqflitePlugin.m
+++ b/sqflite/ios/Classes/SqflitePlugin.m
@@ -126,9 +126,17 @@ static NSInteger _databaseOpenCount = 0;
 
 
 + (void)registerWithRegistrar:(NSObject<FlutterPluginRegistrar>*)registrar {
+#if TARGET_OS_IPHONE
+    FlutterMethodChannel* channel = [FlutterMethodChannel
+                                     methodChannelWithName:_channelName
+                                     binaryMessenger:[registrar messenger]
+                                     codec:[StandardMethodCodec instance]
+                                     taskQueue:[registrar.messenger makeBackgroundTaskQueue]];
+#else
     FlutterMethodChannel* channel = [FlutterMethodChannel
                                      methodChannelWithName:_channelName
                                      binaryMessenger:[registrar messenger]];
+#endif
     SqflitePlugin* instance = [[SqflitePlugin alloc] init];
     [registrar addMethodCallDelegate:instance channel:channel];
 }


### PR DESCRIPTION
fixes https://github.com/tekartik/sqflite/issues/719

This makes all the channel calls happen on thread pool instead of executing on the platform thread.  It is stilla bit inefficient since technically we could be executing the sqlite commands on the thread pool but I had some difficultly implementing it on Android.  Sqlite would complain about getting a connection for all the threads in the thread pool.

This is still an improvement.  With flutter's `customer money` we are seeing sqlite requests happening at startup when the platform thread is very busy so the sqlite requests are being throttled by the platform thread when they have no need to execute on the platform thread.  Especially on Android.