### PR TITLE
Update pub.dev links

### DIFF
--- a/sqflite/pubspec.yaml
+++ b/sqflite/pubspec.yaml
@@ -1,5 +1,6 @@
 name: sqflite
-homepage: https://github.com/tekartik/sqflite/tree/master/sqflite
+repository: https://github.com/tekartik/sqflite/tree/master/sqflite
+issue_tracker: https://github.com/tekartik/sqflite/issues
 description: Flutter plugin for SQLite, a self-contained, high-reliability,
   embedded, SQL database engine.
 version: 2.0.3+1


### PR DESCRIPTION
With this PR, the right section on pub.dev will show the View/report issues link to GitHub again, like [here](https://pub.dev/packages/android_id) (the show-logic was recently changed).