### PR TITLE
API to run batches outside of transactions

### DIFF
--- a/sqflite_common/CHANGELOG.md
+++ b/sqflite_common/CHANGELOG.md
@@ -1,3 +1,8 @@
+## 2.3.0
+
+- Add `startTransaction` parameter to `batch()` to control whether sqflite will
+  start a transaction for this batch or not.
+
 ## 2.2.1+1
 
 * Add debug tag to database factory

--- a/sqflite_common/CHANGELOG.md
+++ b/sqflite_common/CHANGELOG.md
@@ -1,7 +1,7 @@
 ## 2.3.0
 
-- Add `startTransaction` parameter to `batch()` to control whether sqflite will
-  start a transaction for this batch or not.
+- Add `apply()` method to `Batch`. It will execute statements in that batch
+  without starting a new transaction.
 
 ## 2.2.1+1
 

--- a/sqflite_common/lib/sqlite_api.dart
+++ b/sqflite_common/lib/sqlite_api.dart
@@ -219,12 +219,9 @@ abstract class DatabaseExecutor {
   /// batches.
   /// If [batch] is called on a [Transaction], the batch will be committed when
   /// the transaction completes.
-  /// Otherwise, sqflite will start a transaction for this batch if
-  /// [startTransaction] is true (the default). [startTransaction] can be set
-  /// to false for the rare cases where you want to run a batch outside of a
-  /// transaction, or if you are manually starting the transaction to use
-  /// instead of using sqflite's transaction api.
-  Batch batch({bool startTransaction = true});
+  /// Otherwise, sqflite will manage a new transaction for this batch by
+  /// default. For more details, see [Batch.commit].
+  Batch batch();
 }
 
 /// Database transaction
@@ -454,9 +451,21 @@ abstract class Batch {
   /// During [Database.onCreate], [Database.onUpgrade], [Database.onDowngrade]
   /// (we are already in a transaction) or if the batch was created in a
   /// transaction it will only be commited when
-  /// the transaction is commited ([exclusive] is not used then)
-  Future<List<Object?>> commit(
-      {bool? exclusive, bool? noResult, bool? continueOnError});
+  /// the transaction is commited ([exclusive] is not used then).
+  ///
+  /// Otherwise, sqflite will start a transaction for this batch if
+  /// [startTransaction] is true (the default). [startTransaction] can be set
+  /// to false for the rare cases where you want to run a batch outside of a
+  /// transaction, or if you are manually starting the transaction to use
+  /// instead of using sqflite's transaction api.
+  /// When [startTransaction] is false, you may not set [exclusive] to
+  /// `true` since there is no transaction to start exclusively.
+  Future<List<Object?>> commit({
+    bool? startTransaction,
+    bool? exclusive,
+    bool? noResult,
+    bool? continueOnError,
+  });
 
   /// See [Database.rawInsert]
   void rawInsert(String sql, [List<Object?>? arguments]);

--- a/sqflite_common/lib/sqlite_api.dart
+++ b/sqflite_common/lib/sqlite_api.dart
@@ -213,11 +213,18 @@ abstract class DatabaseExecutor {
   /// Creates a batch, used for performing multiple operation
   /// in a single atomic operation.
   ///
-  /// a batch can be commited using [Batch.commit]
+  /// A batch can be commited using [Batch.commit]
   ///
-  /// If the batch was created in a transaction, it will be commited
-  /// when the transaction is done
-  Batch batch();
+  /// To achive atomicity, sqflite will manage a transaction for executed
+  /// batches.
+  /// If [batch] is called on a [Transaction], the batch will be committed when
+  /// the transaction completes.
+  /// Otherwise, sqflite will start a transaction for this batch if
+  /// [startTransaction] is true (the default). [startTransaction] can be set
+  /// to false for the rare cases where you want to run a batch outside of a
+  /// transaction, or if you are manually starting the transaction to use
+  /// instead of using sqflite's transaction api.
+  Batch batch({bool startTransaction = true});
 }
 
 /// Database transaction

--- a/sqflite_common/lib/src/database.dart
+++ b/sqflite_common/lib/src/database.dart
@@ -80,7 +80,7 @@ abstract class SqfliteDatabase extends SqfliteDatabaseExecutor
 
   /// Commit a batch.
   Future<List<Object?>> txnApplyBatch(
-      SqfliteTransaction txn, SqfliteBatch batch,
+      SqfliteTransaction? txn, SqfliteBatch batch,
       {bool? noResult, bool? continueOnError});
 
   /// Execute a command.

--- a/sqflite_common/lib/src/database_mixin.dart
+++ b/sqflite_common/lib/src/database_mixin.dart
@@ -278,8 +278,8 @@ mixin SqfliteDatabaseMixin implements SqfliteDatabase {
       getBaseDatabaseMethodArguments(id!);
 
   @override
-  Batch batch({bool startTransaction = true}) {
-    return SqfliteDatabaseBatch(this, startTransaction);
+  Batch batch() {
+    return SqfliteDatabaseBatch(this);
   }
 
   @override

--- a/sqflite_common/lib/src/database_mixin.dart
+++ b/sqflite_common/lib/src/database_mixin.dart
@@ -278,8 +278,8 @@ mixin SqfliteDatabaseMixin implements SqfliteDatabase {
       getBaseDatabaseMethodArguments(id!);
 
   @override
-  Batch batch() {
-    return SqfliteDatabaseBatch(this);
+  Batch batch({bool startTransaction = true}) {
+    return SqfliteDatabaseBatch(this, startTransaction);
   }
 
   @override
@@ -425,7 +425,7 @@ mixin SqfliteDatabaseMixin implements SqfliteDatabase {
 
   @override
   Future<List<Object?>> txnApplyBatch(
-      SqfliteTransaction txn, SqfliteBatch batch,
+      SqfliteTransaction? txn, SqfliteBatch batch,
       {bool? noResult, bool? continueOnError}) {
     return txnWriteSynchronized(txn, (_) async {
       final arguments = <String, Object?>{paramOperations: batch.operations}

--- a/sqflite_common/lib/src/transaction.dart
+++ b/sqflite_common/lib/src/transaction.dart
@@ -23,9 +23,5 @@ class SqfliteTransaction
   SqfliteTransaction get txn => this;
 
   @override
-  Batch batch({bool startTransaction = true}) {
-    // We're already in a transaction, so we can ignore the [startTransaction]
-    // option.
-    return SqfliteTransactionBatch(this);
-  }
+  Batch batch() => SqfliteTransactionBatch(this);
 }

--- a/sqflite_common/lib/src/transaction.dart
+++ b/sqflite_common/lib/src/transaction.dart
@@ -23,5 +23,9 @@ class SqfliteTransaction
   SqfliteTransaction get txn => this;
 
   @override
-  Batch batch() => SqfliteTransactionBatch(this);
+  Batch batch({bool startTransaction = true}) {
+    // We're already in a transaction, so we can ignore the [startTransaction]
+    // option.
+    return SqfliteTransactionBatch(this);
+  }
 }

--- a/sqflite_common/pubspec.yaml
+++ b/sqflite_common/pubspec.yaml
@@ -1,7 +1,7 @@
 name: sqflite_common
 homepage: https://github.com/tekartik/sqflite/tree/master/sqflite_common
 description: Dart wrapper on SQLite, a self-contained, high-reliability, embedded, SQL database engine.
-version: 2.2.1+1
+version: 2.3.0
 
 environment:
   sdk: '>=2.16.0 <3.0.0'

--- a/sqflite_common_test/lib/batch_test.dart
+++ b/sqflite_common_test/lib/batch_test.dart
@@ -144,7 +144,7 @@ void run(SqfliteTestContext context) {
 
       await db.execute('BEGIN');
 
-      final batch = db.batch(startTransaction: false);
+      final batch = db.batch();
       batch
         ..execute('CREATE TABLE Test (id INTEGER PRIMARY KEY, name TEXT)')
         ..rawInsert('INSERT INTO Test (name) VALUES (?)', ['item1']);
@@ -152,9 +152,10 @@ void run(SqfliteTestContext context) {
       // We should not be able to complete with batch with `exclusive: true`
       // because there is no transaction being managed.
       await expectLater(
-          () => batch.commit(exclusive: true), throwsArgumentError);
+          () => batch.commit(startTransaction: false, exclusive: true),
+          throwsArgumentError);
 
-      await batch.commit(noResult: true);
+      await batch.commit(noResult: true, startTransaction: false);
       await db.execute('COMMIT');
 
       // Sanity check too see whether values have been written

--- a/sqflite_common_test/lib/batch_test.dart
+++ b/sqflite_common_test/lib/batch_test.dart
@@ -149,13 +149,7 @@ void run(SqfliteTestContext context) {
         ..execute('CREATE TABLE Test (id INTEGER PRIMARY KEY, name TEXT)')
         ..rawInsert('INSERT INTO Test (name) VALUES (?)', ['item1']);
 
-      // We should not be able to complete with batch with `exclusive: true`
-      // because there is no transaction being managed.
-      await expectLater(
-          () => batch.commit(startTransaction: false, exclusive: true),
-          throwsArgumentError);
-
-      await batch.commit(noResult: true, startTransaction: false);
+      await batch.apply(noResult: true);
       await db.execute('COMMIT');
 
       // Sanity check too see whether values have been written

--- a/sqflite_test_app/integration_test/sqflite_test.dart
+++ b/sqflite_test_app/integration_test/sqflite_test.dart
@@ -5,7 +5,6 @@
 import 'dart:io';
 
 import 'package:flutter_test/flutter_test.dart';
-// ignore: import_of_legacy_library_into_null_safe
 import 'package:integration_test/integration_test.dart';
 import 'package:sqflite/sqflite.dart';
 import 'package:sqflite_common_ffi/sqflite_ffi.dart';

--- a/sqflite_test_app/pubspec.yaml
+++ b/sqflite_test_app/pubspec.yaml
@@ -43,6 +43,7 @@ dev_dependencies:
   flutter_driver:
     sdk: flutter
   integration_test:
+    sdk: flutter
   sqflite_common_test:
     path: ../sqflite_common_test
   test: '>=1.16.0-nullsafety.10'


### PR DESCRIPTION
In some cases, I want to use batches to reduce the amount of platform channel operations only. In those cases, I don't want `sqflite` to implicitly start a transaction, I want to take care of that myself. An advantage of manually starting transactions is that I'm able to also use savepoints, which sqflite currently doesn't support. At the moment, I can't run batches in my custom transaction manager because batches start a transaction implicitly.

So, I believe that an option to control whether batches start transactions or not could be helpful for those advanced use cases. They continue to start a transaction by default, but there now is an option to disable this default behavior.