### PR TITLE
Fix binding parameters on Android

### DIFF
--- a/sqflite/android/src/main/java/com/tekartik/sqflite/Constant.java
+++ b/sqflite/android/src/main/java/com/tekartik/sqflite/Constant.java
@@ -72,4 +72,6 @@ public class Constant {
 
     // Obsolete since 1.17
     static final public String METHOD_DEBUG_MODE = "debugMode";
+
+    public static final String[] EMPTY_STRING_ARRAY = new String[0];
 }

--- a/sqflite/android/src/test/java/com/tekartik/sqflite/SqlCommandTest.java
+++ b/sqflite/android/src/test/java/com/tekartik/sqflite/SqlCommandTest.java
@@ -41,11 +41,6 @@ public class SqlCommandTest {
                 1.234f,
                 4.5678, // double
                 new byte[]{1, 2, 3}}, command.getSqlArguments());
-        assertArrayEquals(new String[]{"1", "2", "text",
-                "1.234",
-                "4.5678", // double
-                "[1, 2, 3]"}, command.getQuerySqlArguments());
-
     }
 
     @Test
@@ -82,20 +77,5 @@ public class SqlCommandTest {
         assertEquals(command, command.sanitizeForQuery());
         command = new SqlCommand(null, null);
         assertEquals(command, command.sanitizeForQuery());
-        command = new SqlCommand("?,?,?,?,?,?", Arrays.asList((Object) 1L, 2, "text",
-                1.234f,
-                4.5678, // double
-                new byte[]{1, 2, 3}));
-        assertEquals(new SqlCommand("1,2,?,?,?,?", Arrays.asList((Object) "text",
-                1.234f,
-                4.5678, // double
-                new byte[]{1, 2, 3})), command.sanitizeForQuery());
-
-    }
-
-    @Test
-    public void indexedParam() {
-        SqlCommand command = new SqlCommand("?1", Arrays.asList((Object) 1));
-        assertEquals(new SqlCommand("?1", Arrays.asList((Object) 1)), command.sanitizeForQuery());
     }
 }

--- a/sqflite_common_test/lib/type_test.dart
+++ b/sqflite_common_test/lib/type_test.dart
@@ -235,11 +235,7 @@ void run(SqfliteTestContext context) {
         // try blob lookup - does work but not on Android
         var rows = await _data.db
             .rawQuery('SELECT * FROM Test WHERE value = ?', [blob1234]);
-        if (context.isAndroid) {
-          expect(rows.length, 0);
-        } else if (context.isIOS || context.isMacOS || context.isLinux) {
-          expect(rows.length, 1);
-        }
+        expect(rows.length, 1);
 
         // try blob lookup using hex
         rows = await _data.db.rawQuery(


### PR DESCRIPTION
By using a custom cursor factory when executing `SELECT` queries on Android, we get access to the underlying `SQLiteQuery`. Unlike the direct Android API, this class has methods to bind typed values.

This fixes the long-time issue of not being able to properly bind non-string arguments on Android :tada: 

Closes https://github.com/tekartik/sqflite/issues/589.