### PR TITLE
SQLite error 23: authorization denied. When opening database in background while phone is locked

### DIFF
--- a/sqflite/ios/Classes/SqflitePlugin.m
+++ b/sqflite/ios/Classes/SqflitePlugin.m
@@ -587,7 +587,9 @@ static NSInteger _databaseOpenCount = 0;
             if (_log) {
                 NSLog(@"Creating parent dir %@", parentDir);
             }
-            [[NSFileManager defaultManager] createDirectoryAtPath:parentDir withIntermediateDirectories:YES attributes:nil error:&error];
+            [[NSFileManager defaultManager] createDirectoryAtPath:parentDir withIntermediateDirectories:YES attributes:[
+                FileAttributeKey.protectionKey: URLFileProtection.none
+            ] error:&error];
             // Ingore the error, it will break later during open
         }
     }

--- a/sqflite/ios/Classes/SqflitePlugin.m
+++ b/sqflite/ios/Classes/SqflitePlugin.m
@@ -587,9 +587,7 @@ static NSInteger _databaseOpenCount = 0;
             if (_log) {
                 NSLog(@"Creating parent dir %@", parentDir);
             }
-            [[NSFileManager defaultManager] createDirectoryAtPath:parentDir withIntermediateDirectories:YES attributes:[
-                FileAttributeKey.protectionKey: URLFileProtection.none
-            ] error:&error];
+            [[NSFileManager defaultManager] createDirectoryAtPath:parentDir withIntermediateDirectories:YES attributes:@{NSFilePosixPermissions: NSFileProtectionNone} error:&error];
             // Ingore the error, it will break later during open
         }
     }


### PR DESCRIPTION
Due to default [file encryption](https://developer.apple.com/documentation/uikit/protecting_the_user_s_privacy/encrypting_your_app_s_files) `"Complete until first user authentication" ` if app tries to open connection while in background and phone is locked then we get error due to apple privacy & security. This PR fixes that issues and set file permission to none so application which needs to access database from background can access it without error.

Credit to https://github.com/groue/GRDB.swift/issues/571#issuecomment-598830396 for demonstrating POC.

fixes #924 