### PR TITLE
Fix compilation error

### DIFF
--- a/sqflite_common_ffi/lib/src/sqflite_ffi_impl.dart
+++ b/sqflite_common_ffi/lib/src/sqflite_ffi_impl.dart
@@ -357,7 +357,7 @@ class SqfliteFfiDatabase {
       while (true) {
         if (cursor.moveNext()) {
           var row = cursor.current;
-          rows.add(row.values);
+          rows.add(row.values as List<Object?>);
         } else {
           cursorInfo.atEnd = true;
           break;


### PR DESCRIPTION
Seeing the following compilation error:

```
ERROR: .../sqflite_ffi_impl.dart

360: rows.add(row.values); The argument type 'Iterable<dynamic>' can't be assigned to the parameter type 'List<Object?>'.
                           #argument_type_not_assignable
```