### PR TITLE
fix #1018: add missing LIMIT in query when using OFFSET

### DIFF
--- a/sqflite_common/lib/src/sql_builder.dart
+++ b/sqflite_common/lib/src/sql_builder.dart
@@ -127,8 +127,8 @@ class SqlBuilder {
     _writeClause(query, ' GROUP BY ', groupBy);
     _writeClause(query, ' HAVING ', having);
     _writeClause(query, ' ORDER BY ', orderBy);
-    if (limit != null) {
-      _writeClause(query, ' LIMIT ', limit.toString());
+    if (limit != null || offset != null) {
+      _writeClause(query, ' LIMIT ', (limit ?? -1).toString());
     }
     if (offset != null) {
       _writeClause(query, ' OFFSET ', offset.toString());

--- a/sqflite_common/test/sql_builder_test.dart
+++ b/sqflite_common/test/sql_builder_test.dart
@@ -42,6 +42,10 @@ void main() {
       expect(builder.sql,
           'SELECT DISTINCT value FROM test WHERE value = ? GROUP BY group_value HAVING value > 0 ORDER BY other_value LIMIT 2 OFFSET 3');
       expect(builder.arguments, <int>[1]);
+
+      builder = SqlBuilder.query('test', offset: 99);
+      expect(builder.sql, 'SELECT * FROM test LIMIT -1 OFFSET 99');
+      expect(builder.arguments, isNull);
     });
 
     test('insert', () {


### PR DESCRIPTION
This pull reqeuest fixes the missing `LIMIT` clause in the SQLBuilder by providing either the original limit or `-1` (any negative number should be fine) when an offset is set.
This is needed to allow an offset without a limit.

https://sqlite.org/lang_select.html
> If the LIMIT expression evaluates to a negative value, then there is no upper bound on the number of rows returned.

Fixes  #1018.

I tried to accommodate your styles as much as possible, however, feel free to adjust this pull request to your needs.