### PR TITLE
Support v2 of the sqlite3 package

### DIFF
--- a/packages_web/sqflite_common_ffi_web/lib/src/setup/sqlite3_wasm_version.dart
+++ b/packages_web/sqflite_common_ffi_web/lib/src/setup/sqlite3_wasm_version.dart
@@ -1,4 +1,4 @@
 import 'package:pub_semver/pub_semver.dart';
 
 /// Downloaded wasm version.
-var sqlite3WasmVersion = Version(1, 11, 1);
+var sqlite3WasmVersion = Version(2, 0, 0);

--- a/packages_web/sqflite_common_ffi_web/lib/src/sqflite_ffi_impl_web.dart
+++ b/packages_web/sqflite_common_ffi_web/lib/src/sqflite_ffi_impl_web.dart
@@ -21,13 +21,13 @@ class SqfliteFfiHandlerWeb extends SqfliteFfiHandler {
   final SqfliteFfiWebContext context;
 
   WasmSqlite3? _sqlite3;
-  FileSystem? _fs;
+  VirtualFileSystem? _fs;
 
   /// Web handler for common sqlite3 web env
   SqfliteFfiHandlerWeb(this.context);
 
   /// Init file system.
-  Future<FileSystem> initFs() async {
+  Future<VirtualFileSystem> initFs() async {
     _fs ??= context.fs;
     return _fs!;
   }
@@ -52,7 +52,7 @@ class SqfliteFfiHandlerWeb extends SqfliteFfiHandler {
   Future<void> deleteDatabasePlatform(String path) async {
     final fs = await initFs();
     try {
-      fs.deleteFile(path);
+      fs.xDelete(path, 0);
       if (fs is IndexedDbFileSystem) {
         await fs.flush();
       }
@@ -65,8 +65,8 @@ class SqfliteFfiHandlerWeb extends SqfliteFfiHandler {
     // Ignore failure
     try {
       final fs = await initFs();
-      final exists = fs.exists(path);
-      return exists;
+      final canAccess = fs.xAccess(path, 0);
+      return canAccess != 0;
     } catch (_) {
       return false;
     }

--- a/packages_web/sqflite_common_ffi_web/pubspec.yaml
+++ b/packages_web/sqflite_common_ffi_web/pubspec.yaml
@@ -12,7 +12,7 @@ dependencies:
   path: '>=1.7.0 <3.0.0'
   sqflite_common_ffi: '>=2.2.2 <4.0.0'
   sqflite_common: '>=2.4.3 <4.0.0'
-  sqlite3: '>=1.11.1 <3.0.0'
+  sqlite3: '^2.0.0'
   http: '>=0.13.4 <2.0.0'
   js: '>=0.6.4 <2.0.0'
   synchronized: '>=3.0.0+3 <5.0.0'


### PR DESCRIPTION
The native sqflite-ffi implementation is not affected by any breaking changes in the v2 release of `sqlite3`, but the web variant is:

1. The `sqlite3.wasm` interface has changed. Users won't be able to use a `sqlite3.wasm` file compiled for version 1.x of the `sqlite3` package with the latest release.
2. `FileSystem` is now called `VirtualFileSystem` and mirrors the [native sqlite3 interface](https://www.sqlite.org/vfs.html) more closely.
3. We need to explicitly register the VFS instead of passing it to `WasmSqlite3.load`.

I've also made a small optimization by using `WasmSqlite3.loadFromUrl` - it uses `fetch` internally, but without buffering the response in JS.

Unfortunately I was unable to test these changes - the tests in `sqflite_common_ffi_web_test` all unable to load the wasm file (I did run the setup scripts though). Does anything come to mind that I might have broken, or do I need to do more to run those tests?

-------

We now support a newer file system implementation as well, it's based on the [OPFS](https://developer.mozilla.org/en-US/docs/Web/API/File_System_Access_API) API and much more performant and reliable than IndexedDB.
I'm still working on integrating that into drift, but my idea was to write something that checks for supported browser features and then uses OPFS and IndexedDB based on what's available. If you're interested in that as well, I can provide some details and implementation notes for the approach in drift. But the IndexedDB implementation should continue to work for users as is.