### PR TITLE
turn off defense in ffi to allow modifying table sqlite_master

### DIFF
--- a/sqflite_common_ffi/lib/src/sqflite_ffi_impl.dart
+++ b/sqflite_common_ffi/lib/src/sqflite_ffi_impl.dart
@@ -177,6 +177,12 @@ class SqfliteFfiDatabase {
 
   Future<void> _handleExecute({required String sql, List? sqlArguments}) async {
     logSql(sql: sql, sqlArguments: sqlArguments);
+
+    if (sql == "PRAGMA sqflite -- db_config_defensive_off") {
+      final int SQLITE_DBCONFIG_DEFENSIVE = 1010;
+      _ffiDb.config.setIntConfig(SQLITE_DBCONFIG_DEFENSIVE, 0);
+    }
+
     if (sqlArguments?.isNotEmpty ?? false) {
       // devPrint('execute $sql $sqlArguments');
       var preparedStatement = _ffiDb.prepare(sql);


### PR DESCRIPTION
During an upgrade script I alter the original SQL and add foreign keys to the table and encounter a 'table sqlite_master may not be modified' error. 
There was already a known issue (#525) that talked about this and had the workaround mentioned. 

This problem was re-discovered when writing unit tests (using sqflite_common_ffi) for the upgrade scripts. Same error popped up again as FFI does not currently have a workaround for this. 

This PR turns off the SQLITE_DBCONFIG_DEFENSIVE if the SQL command is to set the db_config_defensive_off. 
