### PR TITLE
chore: allow arm64 iphone simulator

### DIFF
--- a/sqflite/ios/sqflite.podspec
+++ b/sqflite/ios/sqflite.podspec
@@ -19,6 +19,6 @@ Accss SQLite database.
 
   s.platform = :ios, '11.0'
   s.ios.deployment_target = '11.0'
-  s.pod_target_xcconfig = { 'DEFINES_MODULE' => 'YES', 'VALID_ARCHS[sdk=iphonesimulator*]' => 'x86_64' }
+  s.pod_target_xcconfig = { 'DEFINES_MODULE' => 'YES', 'EXCLUDED_ARCHS[sdk=iphonesimulator*]' => 'i386' }
 end
 


### PR DESCRIPTION
Actually the podspec is with only VALID_ARCHS to x86. But arm64 can run normally.