### PR TITLE
Remove references to v1 embedding

### DIFF
--- a/sqflite/android/src/main/java/com/tekartik/sqflite/SqflitePlugin.java
+++ b/sqflite/android/src/main/java/com/tekartik/sqflite/SqflitePlugin.java
@@ -82,15 +82,6 @@ public class SqflitePlugin implements FlutterPlugin, MethodCallHandler {
         this.context = context.getApplicationContext();
     }
 
-    //
-    // Plugin registration.
-    //
-    @SuppressWarnings("deprecation")
-    public static void registerWith(io.flutter.plugin.common.PluginRegistry.Registrar registrar) {
-        SqflitePlugin sqflitePlugin = new SqflitePlugin();
-        sqflitePlugin.onAttachedToEngine(registrar.context(), registrar.messenger());
-    }
-
     static private Map<String, Object> fixMap(Map<Object, Object> map) {
         Map<String, Object> newMap = new HashMap<>();
         for (Map.Entry<Object, Object> entry : map.entrySet()) {


### PR DESCRIPTION
Flutter will be removing the remains of the android v1 embedding code and to make that easier for you here is a CL.

Please make a release ASAP that includes this change.