### PR TITLE
Add Isolate DebugName for better debugging

### DIFF
--- a/sqflite_common_ffi/lib/src/isolate_io.dart
+++ b/sqflite_common_ffi/lib/src/isolate_io.dart
@@ -108,7 +108,7 @@ Future<SqfliteIsolate> createIsolate(
   var spawnedIsolate = await Isolate.spawn(_isolate, [
     ourFirstReceivePort.sendPort,
     ffiInit,
-  ]);
+  ], debugName: "SqfliteIsolate");
 
   // the isolate sends us its SendPort as its first message.
   // this lets us communicate with it. we’ll always use this port to


### PR DESCRIPTION
adding Isolate debugName in order to identify the isolate more easily in Call Stack